### PR TITLE
Include Authorization Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ php artisan vendor:publish --provider="Dbfx\LaravelStrapi\LaravelStrapiServicePr
 ```
 
 You need to define your STRAPI_URL and STRAPI_CACHE_TIME in .env:
-You can also define a STRAPI_TOKEN (do not include 'Bearer' only the token itself)
+You can also optionally define a STRAPI_TOKEN to enable authentication. Do not include 'Bearer' only the token itself.
 
 ```
 STRAPI_URL=https://strapi.test.com

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ You can publish the config file with:
 php artisan vendor:publish --provider="Dbfx\LaravelStrapi\LaravelStrapiServiceProvider" --tag="strapi-config"
 ```
 
-You need to define your STRAPI_URL and STRAPI_CACHE_TIME in .env: 
+You need to define your STRAPI_URL and STRAPI_CACHE_TIME in .env:
+You can also define a STRAPI_TOKEN (do not include 'Bearer' only the token itself)
 
 ```
 STRAPI_URL=https://strapi.test.com
 STRAPI_CACHE_TIME=3600
+STRAPI_TOKEN=abcd1234abcd1234
 ```
 
 ## Usage
@@ -82,10 +84,6 @@ $strapi = new LaravelStrapi();
 
 $entries = $strapi->entriesByField('blogs', 'slug', 'test-blog-post');
 ```
-
-## Limitations
-
-This is primarily built around public content (so far). It doesn't yet support authentication, etc. Please consider contributing!
 
 ## Changelog
 

--- a/config/strapi.php
+++ b/config/strapi.php
@@ -6,4 +6,7 @@ return [
 
     // How long to cache results for in seconds
     'cacheTime' => env('STRAPI_CACHE_TIME', 3600),
+
+    // How long to cache results for in seconds
+    'token' => env('STRAPI_TOKEN', null),
 ];

--- a/config/strapi.php
+++ b/config/strapi.php
@@ -7,6 +7,6 @@ return [
     // How long to cache results for in seconds
     'cacheTime' => env('STRAPI_CACHE_TIME', 3600),
 
-    // How long to cache results for in seconds
+    // Token for authentication
     'token' => env('STRAPI_TOKEN', null),
 ];

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -28,15 +28,14 @@ class LaravelStrapi
 
         // Fetch and cache the collection type
         $collection = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $sortKey, $sortOrder, $limit, $start) {
-            $response = Http::get($url . '/' . $type . '?_sort=' . $sortKey . ':' . $sortOrder . '&_limit=' . $limit . '&_start=' . $start);
-
+            $response = Http::withHeaders(['Authorization' => 'Bearer '.env('STRAPI_TOKEN')])->get($url . '/' . $type . '?_sort=' . $sortKey . ':' . $sortOrder . '&_limit=' . $limit . '&_start=' . $start);
             return $response->json();
         });
 
-        if (isset($collection['statusCode']) && $collection['statusCode'] === 403) {
+        if (isset($collection['statusCode']) && $collection['statusCode'] >= 400) {
             Cache::forget($cacheKey);
 
-            throw new PermissionDenied('Strapi returned a 403 Forbidden');
+            throw new PermissionDenied('Strapi returned a '.$collection['statusCode']);
         }
 
         if (!is_array($collection)) {
@@ -62,7 +61,7 @@ class LaravelStrapi
         $url = $this->strapiUrl;
 
         return Cache::remember(self::CACHE_KEY . '.collectionCount.' . $type, $this->cacheTime, function () use ($url, $type) {
-            $response = Http::get($url . '/' . $type . '/count');
+            $response = Http::withHeaders(['Authorization' => 'Bearer '.env('STRAPI_TOKEN')])->get($url . '/' . $type . '/count');
 
             return $response->json();
         });
@@ -74,15 +73,15 @@ class LaravelStrapi
         $cacheKey = self::CACHE_KEY . '.entry.' . $type . '.' . $id;
 
         $entry = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $id) {
-            $response = Http::get($url . '/' . $type . '/' . $id);
+            $response = Http::withHeaders(['Authorization' => 'Bearer '.env('STRAPI_TOKEN')])->get($url . '/' . $type . '/' . $id);
 
             return $response->json();
         });
 
-        if (isset($entry['statusCode']) && $entry['statusCode'] === 403) {
+        if (isset($entry['statusCode']) && $entry['statusCode'] >= 400) {
             Cache::forget($cacheKey);
 
-            throw new PermissionDenied('Strapi returned a 403 Forbidden');
+            throw new PermissionDenied('Strapi returned a '.$entry['statusCode']);
         }
 
         if (!isset($entry['id'])) {
@@ -108,15 +107,15 @@ class LaravelStrapi
         $cacheKey = self::CACHE_KEY . '.entryByField.' . $type . '.' . $fieldName . '.' . $fieldValue;
 
         $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue) {
-            $response = Http::get($url . '/' . $type . '?' . $fieldName . '=' . $fieldValue);
+            $response = Http::withHeaders(['Authorization' => 'Bearer '.env('STRAPI_TOKEN')])->get($url . '/' . $type . '?' . $fieldName . '=' . $fieldValue);
 
             return $response->json();
         });
 
-        if (isset($entries['statusCode']) && $entries['statusCode'] === 403) {
+        if (isset($entries['statusCode']) && $entries['statusCode'] >= 400) {
             Cache::forget($cacheKey);
 
-            throw new PermissionDenied('Strapi returned a 403 Forbidden');
+            throw new PermissionDenied('Strapi returned a '.$entries['statusCode']);
         }
 
         if (!is_array($entries)) {
@@ -143,15 +142,15 @@ class LaravelStrapi
 
         // Fetch and cache the collection type
         $single = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type) {
-            $response = Http::get($url . '/' . $type);
+            $response = Http::withHeaders(['Authorization' => 'Bearer '.env('STRAPI_TOKEN')])->get($url . '/' . $type);
 
             return $response->json();
         });
 
-        if (isset($single['statusCode']) && $single['statusCode'] === 403) {
+        if (isset($single['statusCode']) && $single['statusCode'] >= 400) {
             Cache::forget($cacheKey);
 
-            throw new PermissionDenied('Strapi returned a 403 Forbidden');
+            throw new PermissionDenied('Strapi returned a '.$single['statusCode']);
         }
 
         if (! isset($single['id'])) {

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -14,7 +14,7 @@ class LaravelStrapi
 
     private string $strapiUrl;
     private int $cacheTime;
-    private string $token;
+    private $token;
     private array $headers = [];
 
     public function __construct()


### PR DESCRIPTION
I added authorization to all requests.

The STRAPI_TOKEN in the .env is optional if strapi is public.
A header is appended anyway (with an empty token), but I've tested that it still works on both public and private API, with and without defining the token in the env. Private API without the token, returns a 403 of course.

Since the cache would also cache 404s or other errors (e.g. when you provide a wrong url), I changed the cache to forget whenever response is 400 or higher.

README.md is updated accordingly.