### PR TITLE
Strapi v4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,15 @@ There are several useful options available as well.
 - ```$fullUrls``` will automatically add your STRAPI_URL to the front of any relative URLs (e.g. images, etc).
 - ```$limit``` sets how many items you are requesting
 - ```$start``` is the offset to be used with limit, useful for pagination
+- ```$populate``` is an array containing the fields to populate
 
 ```php
 use Dbfx\LaravelStrapi\LaravelStrapi;
 
 $strapi = new LaravelStrapi();
-$blogs = $strapi->collection('blogs', $sortKey = 'id', $sortOrder = 'DESC', $limit = 20, $start = 0, $fullUrls = true);
+$blogs = $strapi->collection('blogs', $sortKey = 'id', $sortOrder = 'DESC', $limit = 20, $start = 0, $fullUrls = true, $populate = ['author', 'images']);
 
-$entry = $strapi->entry('blogs', 1, $fullUrls = true);
+$entry = $strapi->entry('blogs', 1, $fullUrls = true, $populate = ['author', 'images']);
 ```
 
 You may also access Single Type items as follows: 

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -109,14 +109,21 @@ class LaravelStrapi
         return $entry;
     }
 
-    public function entriesByField(string $type, string $fieldName, $fieldValue, $fullUrls = true): array
+    public function entriesByField(string $type, string $fieldName, $fieldValue, $fullUrls = true, array $populate = (array) null): array
     {
         $url = $this->strapiUrl;
         $cacheKey = self::CACHE_KEY . '.entryByField.' . $type . '.' . $fieldName . '.' . $fieldValue;
 
-        $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue) {
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?filters[' . $fieldName . '][$eq]=' . $fieldValue);
-
+        $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue, $populate) {
+            $populateString = '';
+            if(!empty($populate)) { 
+                foreach($populate as $key => $value) {
+                    $populateString = $populateString . '&populate[' . $key . ']=' . $value;
+                }
+            }
+                
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?filters[' . $fieldName . '][$eq]=' . $fieldValue . $populateString);
+            
             return $response->json();
         });
 

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -115,7 +115,7 @@ class LaravelStrapi
         $cacheKey = self::CACHE_KEY . '.entryByField.' . $type . '.' . $fieldName . '.' . $fieldValue;
 
         $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue) {
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?[' . $fieldName . '][$eq]=' . $fieldValue);
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?filters[' . $fieldName . '][$eq]=' . $fieldValue);
 
             return $response->json();
         });

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -217,7 +217,7 @@ class LaravelStrapi
     {
         $populateString = '';
 
-        foreach($populate as $key => $value) {
+        foreach($array as $key => $value) {
             if($key == 0) {
                 $populateString = 'populate[' . $key . ']=' . $value;
             } else {

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -109,7 +109,7 @@ class LaravelStrapi
         return $entry;
     }
 
-    public function entriesByField(string $type, string $fieldName, $fieldValue, $fullUrls = true, array $populate = (array) null): array
+    public function entriesByField(string $type, string $fieldName, $fieldValue, $fullUrls = true, array $populate = array()): array
     {
         $url = $this->strapiUrl;
         $cacheKey = self::CACHE_KEY . '.entryByField.' . $type . '.' . $fieldName . '.' . $fieldValue;

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -28,14 +28,15 @@ class LaravelStrapi
         }
     }
 
-    public function collection(string $type, $sortKey = 'id', $sortOrder = 'DESC', $limit = 20, $start = 0, $fullUrls = true): array
+    public function collection(string $type, $sortKey = 'id', $sortOrder = 'DESC', $limit = 20, $start = 0, $fullUrls = true, array $populate = array()): array
     {
         $url = $this->strapiUrl;
         $cacheKey = self::CACHE_KEY . '.collection.' . $type . '.' . $sortKey . '.' . $sortOrder . '.' . $limit . '.' . $start;
+        $populateString = $this->createPopulateString($populate);
 
         // Fetch and cache the collection type
-        $collection = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $sortKey, $sortOrder, $limit, $start) {
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?sort[0]=' . $sortKey . ':' . $sortOrder . '&pagination[limit]=' . $limit . '&pagination[start]=' . $start);
+        $collection = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $sortKey, $sortOrder, $limit, $start, $populateString) {
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?sort[0]=' . $sortKey . ':' . $sortOrder . '&pagination[limit]=' . $limit . '&pagination[start]=' . $start . '&' . $populateString);
 
             return $response->json();
         });
@@ -75,13 +76,14 @@ class LaravelStrapi
         });
     }
 
-    public function entry(string $type, int $id, $fullUrls = true): array
+    public function entry(string $type, int $id, $fullUrls = true, array $populate = array()): array
     {
         $url = $this->strapiUrl;
         $cacheKey = self::CACHE_KEY . '.entry.' . $type . '.' . $id;
+        $populateString = $this->createPopulateString($populate);
 
-        $entry = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $id) {
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '/' . $id);
+        $entry = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $id, $populateString) {
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '/' . $id . '?' . $populateString);
 
             return $response->json();
         });
@@ -113,15 +115,12 @@ class LaravelStrapi
     {
         $url = $this->strapiUrl;
         $cacheKey = self::CACHE_KEY . '.entryByField.' . $type . '.' . $fieldName . '.' . $fieldValue;
+        $populateString = $this->createPopulateString($populate);
 
-        $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue, $populate) {
-            $populateString = '';
-            foreach($populate as $key => $value) {
-                $populateString = $populateString . '&populate[' . $key . ']=' . $value;
-            }
-                
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?filters[' . $fieldName . '][$eq]=' . $fieldValue . $populateString);
-            
+        $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue, $populateString) {
+
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?filters[' . $fieldName . '][$eq]=' . $fieldValue . '&' . $populateString);
+
             return $response->json();
         });
 
@@ -148,14 +147,15 @@ class LaravelStrapi
         return $entries;
     }
 
-    public function single(string $type, string $pluck = null, $fullUrls = true)
+    public function single(string $type, string $pluck = null, $fullUrls = true, array $populate = array())
     {
         $url = $this->strapiUrl;
         $cacheKey = self::CACHE_KEY . '.single.' . $type;
+        $populateString = $this->createPopulateString($populate);
 
         // Fetch and cache the collection type
-        $single = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type) {
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type);
+        $single = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $populateString) {
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?' . $populateString);
 
             return $response->json();
         });
@@ -207,5 +207,24 @@ class LaravelStrapi
         }
 
         return $array;
+    }
+
+    /**
+     * This function transforms an array of fields to populate into a string
+     * to add to the end of the request URL.
+     */
+    private function createPopulateString($array): string
+    {
+        $populateString = '';
+
+        foreach($populate as $key => $value) {
+            if($key == 0) {
+                $populateString = 'populate[' . $key . ']=' . $value;
+            } else {
+                $populateString = $populateString . '&populate[' . $key . ']=' . $value;
+            }
+        }
+
+        return $populateString;
     }
 }

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -116,10 +116,8 @@ class LaravelStrapi
 
         $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue, $populate) {
             $populateString = '';
-            if(!empty($populate)) { 
-                foreach($populate as $key => $value) {
-                    $populateString = $populateString . '&populate[' . $key . ']=' . $value;
-                }
+            foreach($populate as $key => $value) {
+                $populateString = $populateString . '&populate[' . $key . ']=' . $value;
             }
                 
             $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?filters[' . $fieldName . '][$eq]=' . $fieldValue . $populateString);

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -35,7 +35,7 @@ class LaravelStrapi
 
         // Fetch and cache the collection type
         $collection = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $sortKey, $sortOrder, $limit, $start) {
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?_sort=' . $sortKey . ':' . $sortOrder . '&_limit=' . $limit . '&_start=' . $start);
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?sort[0]=' . $sortKey . ':' . $sortOrder . '&pagination[limit]=' . $limit . '&pagination[start]=' . $start);
 
             return $response->json();
         });

--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -115,7 +115,7 @@ class LaravelStrapi
         $cacheKey = self::CACHE_KEY . '.entryByField.' . $type . '.' . $fieldName . '.' . $fieldValue;
 
         $entries = Cache::remember($cacheKey, $this->cacheTime, function () use ($url, $type, $fieldName, $fieldValue) {
-            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?' . $fieldName . '=' . $fieldValue);
+            $response = Http::withHeaders($this->headers)->get($url . '/' . $type . '?[' . $fieldName . '][$eq]=' . $fieldValue);
 
             return $response->json();
         });


### PR DESCRIPTION
Strapi v4 changed the sorting parameters.

See v3 docs: [https://docs-v3.strapi.io/developer-docs/latest/developer-resources/content-api/content-api.html#sort](https://docs-v3.strapi.io/developer-docs/latest/developer-resources/content-api/content-api.html#sort)
And compare with v4 docs: [https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#sorting)

This commit uses the Strapi v4 syntax.