### PR TITLE
An unknown Strapi error was returned (LaravelStrapi.php:176)

### DIFF
--- a/src/LaravelStrapi.php
+++ b/src/LaravelStrapi.php
@@ -166,7 +166,7 @@ class LaravelStrapi
             throw new PermissionDenied('Strapi returned a ' . $single['statusCode']);
         }
 
-        if (! isset($single['id'])) {
+        if ( !isset($single['id']) && !isset($single['data']['id'])) {
             Cache::forget($cacheKey);
 
             if ($single === null) {


### PR DESCRIPTION
Try to execute:
`$strapi = new LaravelStrapi;`
`$strapi->single('home-page');`

For the exact same reason as Issue #15 bur for single, the following error is raised: 

> An unknown Strapi error was returned

Same fix applied as for Issue #15 on `LaravelStrapi::single() function`